### PR TITLE
Prevent routes file write if content is identical

### DIFF
--- a/lib/webpacker/routes/railtie.rb
+++ b/lib/webpacker/routes/railtie.rb
@@ -7,8 +7,8 @@ module Webpacker
       config.webpacker.routes.default_url_options = {}
       config.webpacker.routes.camel_case = false
 
-      config.after_initialize do |app|
-        generate = -> { Webpacker::Routes.generate(app.tap(&:reload_routes!)) }
+      initializer 'webpacker.routes', :after => :set_routes_reloader_hook do |app|
+        generate = -> { Webpacker::Routes.generate(app) }
         if Rails::VERSION::MAJOR >= 5
           app.reloader.to_run(&generate)
         else

--- a/lib/webpacker/routes/railtie.rb
+++ b/lib/webpacker/routes/railtie.rb
@@ -7,14 +7,13 @@ module Webpacker
       config.webpacker.routes.default_url_options = {}
       config.webpacker.routes.camel_case = false
 
-      initializer 'webpacker.routes', :after => :set_routes_reloader_hook do |app|
-        generate = -> { Webpacker::Routes.generate(app) }
+      config.after_initialize do |app|
         if Rails::VERSION::MAJOR >= 5
-          app.reloader.to_run(&generate)
+          app.reloader.to_run(:after) { Webpacker::Routes.generate(app) }
         else
-          ActionDispatch::Reloader.to_prepare(&generate)
+          ActionDispatch::Reloader.to_prepare(:after) { Webpacker::Routes.generate(app) }
         end
-        generate.call unless ENV['WEBPACKER_ROUTES_INSTALL'] == 'true'
+        Webpacker::Routes.generate(app.tap(&:reload_routes!)) unless ENV['WEBPACKER_ROUTES_INSTALL']
       end
     end
   end


### PR DESCRIPTION
This keeps webpack-dev-server from recompiling when the content of the
generated routes file didn't change. I looked into using
`app.routes_reloader` to detect changes, but that didn't work when the
routes file(s) reference other classes or modules (which I think is a
somewhat common way of splitting apart large routes files).

I wanted to keep using `File.atomic_write`, so this uses throw/catch to
prevent the write if the tempfile is identical to the existing file.

Addresses the same issue as: #8