### PR TITLE
Add metadata.source_code_uri to gemspec

### DIFF
--- a/webpacker-routes.gemspec
+++ b/webpacker-routes.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |s|
   s.summary     = "Convert Rails routes to JavaScript modules"
   s.license     = "MIT"
 
+  s.metadata = {
+      'source_code_uri' => 'https://github.com/davishmcclurg/webpacker-routes',
+  }
+
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.2"


### PR DESCRIPTION
Hi David! Thanks for sharing this nice library. Would you consider adding this to your next update?

Added to `metadata.source_code_uri` to `gemspec` file. With these values, Dependabot is able to create PRs with links to the source and the changelog. With these links it becomes quicker to asses updates.

## Examples
PR for `webpacker-routes`, without links
![image](https://user-images.githubusercontent.com/15790266/71158962-252cc400-2245-11ea-9baf-109b13ae76fc.png)

PR for `webpacker`, with links and changelog excerpt
![image](https://user-images.githubusercontent.com/15790266/71159049-468db000-2245-11ea-840d-df3ad2db4ed7.png)
