### PR TITLE
Support Rails engine routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Import individual routes from any Webpacker-compiled file:
 
 ```javascript
 import { root_path, root_url } from 'routes'
+import { engine_path } from 'routes/engine_name'
 
 root_path()
 // /

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -1,5 +1,5 @@
 say "Creating JavaScript app source directory"
-file Webpacker.config.routes_path.join('.gitignore'), "/index.js\n"
+file Webpacker.config.routes_path.join('.gitignore'), "*\n!.gitignore\n"
 
 say "Installing all JavaScript dependencies"
 run "yarn add webpacker-routes@#{Webpacker::Routes::VERSION} --exact"

--- a/lib/webpacker/routes.rb
+++ b/lib/webpacker/routes.rb
@@ -22,42 +22,71 @@ module Webpacker
         default_url_options.merge!(config.default_url_options)
         default_url_options.except!(*IGNORED_OPTIONS)
 
+        parent_spec_var = var_name.call('parent_spec')
         default_url_options_var = var_name.call('default_url_options')
 
-        js_file = Webpacker.config.routes_path.join('index.js')
+        route_sets = [[app.routes, nil, Webpacker.config.routes_path]]
+        visited_directories = []
 
-        catch(:identical) do
-          File.atomic_write(js_file) do |temp_file|
-            temp_file.write(<<-JAVASCRIPT.strip_heredoc)
-              import { urlFor, pathFor } from 'webpacker-routes'
-              const #{default_url_options_var} = #{js(default_url_options)}
-            JAVASCRIPT
+        while (route_set, parent, directory = route_sets.shift)
+          directory.mkpath
+          visited_directories << directory
+          js_file = directory.join('index.js')
 
-            app.routes.named_routes.sort_by(&:first).each do |name, route|
-              raise `Invalid route name for javascript: ${name}` unless JAVASCRIPT_VARIABLE_NAME_REGEX =~ name
-
-              spec = route.path.spec.to_s
-              segment_keys = route.segment_keys.uniq
-              options = route.defaults.except(*IGNORED_OPTIONS)
-
-              spec_var = var_name.call("#{name}_spec")
-              url_var = var_name.call("#{name}_url")
-              path_var = var_name.call("#{name}_path")
+          catch(:identical) do
+            File.atomic_write(js_file) do |temp_file|
+              parent_var_definition = if parent
+                "import { #{parent} as #{parent_spec_var} } from '../'"
+              else
+                "const #{parent_spec_var} = null"
+              end
 
               temp_file.write(<<-JAVASCRIPT.strip_heredoc)
-                const #{spec_var} = [#{js(spec)}, #{js(segment_keys)}, { ...#{default_url_options_var}, ...#{js(options)} }]
-                export const #{url_var} = (...args) => urlFor(#{spec_var}, ...args)
-                export const #{path_var} = (...args) => pathFor(#{spec_var}, ...args)
+                import { urlFor, pathFor } from 'webpacker-routes'
+                #{parent_var_definition}
+                const #{default_url_options_var} = #{js(default_url_options)}
               JAVASCRIPT
-            end
 
-            temp_file.close
-            if identical?(js_file.to_s, temp_file.path)
-              temp_file.unlink
-              throw :identical
+              route_set.named_routes.sort_by(&:first).each do |name, route|
+                raise `Invalid route name for javascript: ${name}` unless JAVASCRIPT_VARIABLE_NAME_REGEX =~ name
+
+                spec = route.path.spec.to_s
+                segment_keys = route.segment_keys.uniq
+                options = route.defaults.except(*IGNORED_OPTIONS)
+
+                spec_var = var_name.call("#{name}_spec")
+                url_var = var_name.call("#{name}_url")
+                path_var = var_name.call("#{name}_path")
+
+                temp_file.write(<<-JAVASCRIPT.strip_heredoc)
+                  export const #{spec_var} = [#{js(spec)}, #{js(segment_keys)}, { ...#{default_url_options_var}, ...#{js(options)} }, #{parent_spec_var}]
+                  export const #{url_var} = (...args) => urlFor(#{spec_var}, ...args)
+                  export const #{path_var} = (...args) => pathFor(#{spec_var}, ...args)
+                JAVASCRIPT
+
+                if engine?(route)
+                  engine = rack_app(route)
+                  engine_name = engine.railtie_name
+
+                  raise `Invalid engine name for javascript: ${engine_name}` unless JAVASCRIPT_VARIABLE_NAME_REGEX =~ engine_name
+
+                  engine_name_var = var_name.call(engine_name)
+
+                  route_sets << [engine.routes, spec_var, directory.join(engine_name_var)]
+                end
+              end
+
+              temp_file.close
+              if identical?(js_file.to_s, temp_file.path)
+                temp_file.unlink
+                throw :identical
+              end
             end
           end
         end
+
+        extra_directories = Webpacker.config.routes_path.glob('**/*').select(&:directory?) - visited_directories
+        extra_directories.sort_by { |directory| directory.to_s.size }.reverse_each(&:rmtree)
       end
 
     private
@@ -70,6 +99,15 @@ module Webpacker
         FileUtils.compare_file(path1, path2)
       rescue Errno::ENOENT
         false
+      end
+
+      def rack_app(route)
+        route.app.app
+      end
+
+      def engine?(route)
+        app = rack_app(route)
+        app.is_a?(Class) && app < Rails::Engine
       end
     end
   end

--- a/test/dummy/app/javascript/routes/.gitignore
+++ b/test/dummy/app/javascript/routes/.gitignore
@@ -1,1 +1,2 @@
-/index.js
+*
+!.gitignore

--- a/test/webpacker/routes_test.rb
+++ b/test/webpacker/routes_test.rb
@@ -79,4 +79,51 @@ class Webpacker::Routes::Test < ActiveSupport::TestCase
     assert_no_match(/\/tree\/shook/, output)
     Rails.application.reload_routes!
   end
+
+  test 'rails engine' do
+    class ::TestEngine3 < Rails::Engine; end
+    class ::TestEngine2 < Rails::Engine; end
+    class ::TestEngine1 < Rails::Engine; end
+
+    ::TestEngine3.routes.draw do
+      get 'bleh' => 'bleh#bleh'
+    end
+    ::TestEngine2.routes.draw do
+      root 'root#root'
+      get 'foo' => 'foo#foo'
+    end
+    ::TestEngine1.routes.draw do
+      mount ::TestEngine2, at: 'two/:engine2_id'
+      get 'bar' => 'bar#bar'
+    end
+    Rails.application.routes.draw do
+      root 'application#index'
+      mount ::TestEngine1, at: 'one/:engine1_id'
+      mount ::TestEngine3, at: 'three'
+      get 'baz' => 'baz#baz'
+    end
+
+    context = ExecJS.compile(compile(<<-JAVASCRIPT))
+      import * as routes from 'routes'
+      import * as engine1_routes from 'routes/test_engine1'
+      import * as engine2_routes from 'routes/test_engine1/test_engine2'
+      import * as engine3_routes from 'routes/test_engine3'
+      global.__routes__ = routes
+      global.__engine1_routes__ = engine1_routes
+      global.__engine2_routes__ = engine2_routes
+      global.__engine3_routes__ = engine3_routes
+    JAVASCRIPT
+
+    assert_equal('/', context.eval('__routes__.root_path()'))
+    assert_equal('/one/1/bar', context.eval('__engine1_routes__.bar_path({ engine1_id: "1" })'))
+    assert_equal('/one/1/two/2', context.eval('__engine1_routes__.test_engine2_path({ engine1_id: "1", engine2_id: "2" })'))
+    assert_equal('/one/1/two/2/', context.eval('__engine2_routes__.root_path({ engine1_id: "1", engine2_id: "2" })'))
+    assert_equal('/one/1/two/2/foo', context.eval('__engine2_routes__.foo_path({ engine1_id: "1", engine2_id: "2" })'))
+    assert_equal('/one/1/two/2/foo?foo=bar', context.eval('__engine2_routes__.foo_path({ engine1_id: "1", engine2_id: "2", foo: "bar" })'))
+    assert_equal('http://example.com/one/1/two/2/foo?foo=bar', context.eval('__engine2_routes__.foo_url({ host: "http://example.com", engine1_id: "1", engine2_id: "2", foo: "bar" })'))
+    assert_equal('/overwrite/foo', context.eval('__engine2_routes__.foo_path({ script_name: "/overwrite" })'))
+    assert_equal('/three/bleh', context.eval('__engine3_routes__.bleh_path()'))
+    assert_equal('/three/bleh?foo=bar', context.eval('__engine3_routes__.bleh_path({ foo: "bar" })'))
+    Rails.application.reload_routes!
+  end
 end


### PR DESCRIPTION
This generates a separate routes module for each Rails engine so that
they can be used like Rails helpers: https://edgeguides.rubyonrails.org/engines.html#routes

> To make this route always use the engine's articles_path routing
> helper method, we must call the method on the routing proxy method
> that shares the same name as the engine.
>
> ```
> <%= link_to "Blog articles", blorgh.articles_path %>
> ```

With this change, the javascript version is:

```
import { articles_path } from 'routes/blorgh'
```

Which I think preserves the idea of route isolation.

---

To make this work, engine routes import their parent's route spec and
parse out any relevant segment keys pass to the parent route helper,
similar to how Rails handles it: https://github.com/rails/rails/blob/fa292703e1b733a7a55a8d6f0d749ddf590c61fd/actionpack/lib/action_dispatch/routing/mapper.rb#L688-L719

I pulled the `rack_app` and `engine?` methods from Rails: https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/actionpack/lib/action_dispatch/routing/endpoint.rb#L10-L14
I believe it should support Rails 4-6.

Any leftover routes directories should be cleaned up by the
`visited_directories` check if an engine is removed.

---

There is a slight compatibility issue with the `.gitignore` file, since
old installs will not have all engine directories ignored. Any upgrades
should update `app/javascript/routes/.gitignore` to:

```
*
!.gitignore
```

---

Addresses the same issue as: https://github.com/davishmcclurg/webpacker-routes/pull/12